### PR TITLE
Created get-engines endpoint

### DIFF
--- a/emission_analyzer_api/urls.py
+++ b/emission_analyzer_api/urls.py
@@ -1,11 +1,12 @@
 from django.urls import path
-from .views import addUser, addEngine, getUser #importing the methods from views.py which are used to parse the json data and return the response
-
+#importing the methods from views.py which are used to parse the json data and return the response
+from .views import addUser, addEngine, getUser, getEngines
 from . import views
 
 urlpatterns = [
     path("", views.index, name="index"),
     path("add-user/", addUser, name="add_user"),
     path("add-engine/", addEngine, name="add_engine"),
-    path("get_user/<str:user_id>", getUser, name="get_user")
+    path("get_user/<str:user_id>", getUser, name="get_user"),
+    path("get-engines/<str:user_id>", getEngines, name="get_engines")
 ]

--- a/emission_analyzer_api/views.py
+++ b/emission_analyzer_api/views.py
@@ -21,6 +21,37 @@ def getUser(request, user_id):
     return JsonResponse({"error": "invalid request method"}, status=405)
 
 @csrf_exempt
+def getEngines(request, user_id):
+    if request.method == "GET":
+        try:
+            user = User.objects.get(user_id=user_id)
+            
+            # Get all engines for this user
+            engines = Engine.objects.filter(user=user)
+            
+            # Format engines as a list of dictionaries
+            engines_list = []
+            for engine in engines:
+                engines_list.append({
+                    "engine_identification": engine.engine_identification,
+                    "engine_type": engine.engine_type.type,
+                    "rated_thrust": float(engine.rated_thrust),
+                    "bp_ratio": float(engine.bp_ratio),
+                    "pressure_ratio": float(engine.pressure_ratio)
+                })
+            
+            # Return the user_id and list of engines
+            return JsonResponse({
+                "user_id": user_id,
+                "engines": engines_list
+            }, status=200)
+            
+        except User.DoesNotExist:
+            return JsonResponse({'error': 'User not found'}, status=404)
+        
+    return JsonResponse({"error": "invalid request method"}, status=405)
+
+@csrf_exempt
 def addUser(request):
     if request.method == "POST":
         try:


### PR DESCRIPTION
I created an endpoint called get-engines, which takes in the user id and lists all the engines associated with that user, inputted like this:
![Screenshot 2025-04-02 192243](https://github.com/user-attachments/assets/c035c559-f18e-4b4c-a55f-886f3d3e28ff)
To make things clear, the endpoint is get-engines/{user_id}.


The output shows the user's id followed by the list of engines associated with the user.

![image](https://github.com/user-attachments/assets/26d4bcb0-f48f-4f09-936e-0c3daed813ec)

To add another engine with that user, I first made sure the user is in the database by testing with the get_user endpoint. Then I called the add-engine endpoint to add another engine for that user, which is then appended to the engine list. Finally, I ran get-engines, and the user id and the list of engines are successfully shown on Postman.

To verify that the engine is indeed added to the database, I queried the database's engine table by "SELECT * FROM emission_analyzer_api_engine;". Here is a screenshot below:

![image](https://github.com/user-attachments/assets/3e026b79-f1f0-4a28-b82a-64555db3d063)