### PR TITLE
created engine database tests

### DIFF
--- a/emission_analyzer_api/models.py
+++ b/emission_analyzer_api/models.py
@@ -12,7 +12,7 @@ class EngineType(models.Model):
 
 class Engine(models.Model):
     user = models.ForeignKey(User, on_delete=models.CASCADE, null=False)
-    engine_type = models.ForeignKey(EngineType, on_delete=models.SET_NULL, null=True)
+    engine_type = models.ForeignKey(EngineType, on_delete=models.CASCADE, null=False) #Engine type is now required to be enforced
     engine_identification = models.CharField(max_length=100, null=False, unique=False)
     rated_thrust = models.DecimalField(max_digits=10, decimal_places=2, null=False)
     bp_ratio = models.DecimalField(max_digits=10, decimal_places=2, null=False)

--- a/emission_analyzer_api/tests/engine.py
+++ b/emission_analyzer_api/tests/engine.py
@@ -43,10 +43,12 @@ class EngineModelTest(TestCase):
             Engine.objects.create(**engine_data)
 
     def test_missing_engine_type(self):
-        """Test that missing engine type raises IntegrityError (engine_type must be present)"""
+        """Test that missing engine type raises ValidationError (engine_type must be present)"""
         engine_data = self.generate_engine_data(engine_type=None)
-        with self.assertRaises(IntegrityError):
-            Engine.objects.create(**engine_data)
+        engine = Engine(**engine_data)
+        with self.assertRaises(ValidationError):
+            engine.full_clean()
+
 
     def test_missing_identification(self):
         """Test that missing engine_identification raises ValidationError (engine_identification is required)"""

--- a/emission_analyzer_api/tests/engine.py
+++ b/emission_analyzer_api/tests/engine.py
@@ -1,0 +1,74 @@
+from django.test import TestCase
+from django.core.exceptions import ValidationError
+from django.db.utils import IntegrityError
+from emission_analyzer_api.models import Engine, User, EngineType
+import random
+
+class EngineModelTest(TestCase):
+
+    @classmethod
+    def setUp(cls):
+        """Sets up the test environment by creating a user and engine type"""
+        cls.user = User.objects.create(user_id="engine_test_user")
+        cls.engine_type = EngineType.objects.create(type="turbofan")
+
+    def generate_engine_data(self, **overrides):
+        """Creates randomized engine data for testing with optional overrides"""
+        data = {
+            "user": self.user,
+            "engine_type": self.engine_type,
+            "engine_identification": "ENGINE_" + str(random.randint(1000, 9999)),
+            "rated_thrust": random.random() * 30,
+            "bp_ratio": random.random() * 10,
+            "pressure_ratio": random.random() * 10,
+        }
+        data.update(overrides)
+        return data
+
+    def test_valid_engine_creation(self):
+        """Test that a valid engine can be created with all required fields"""
+        engine_data = self.generate_engine_data()
+        engine = Engine.objects.create(**engine_data)
+        saved_engine = Engine.objects.get(pk=engine.pk)
+
+        # Verifies that the engine was created with correct data
+        self.assertEqual(saved_engine.user, self.user)
+        self.assertEqual(saved_engine.engine_type, self.engine_type)
+        self.assertEqual(saved_engine.engine_identification, engine_data["engine_identification"])
+
+    def test_missing_user(self):
+        """Test that missing user raises IntegrityError (user_id must be present)"""
+        engine_data = self.generate_engine_data(user=None)
+        with self.assertRaises(IntegrityError):
+            Engine.objects.create(**engine_data)
+
+    def test_missing_engine_type(self):
+        """Test that missing engine type raises IntegrityError (engine_type must be present)"""
+        engine_data = self.generate_engine_data(engine_type=None)
+        with self.assertRaises(IntegrityError):
+            Engine.objects.create(**engine_data)
+
+    def test_missing_identification(self):
+        """Test that missing engine_identification raises ValidationError (engine_identification is required)"""
+        engine_data = self.generate_engine_data(engine_identification=None)
+        engine = Engine(**engine_data)
+        with self.assertRaises(ValidationError):
+            engine.full_clean()
+
+    def test_invalid_data_types(self):
+        """Test that invalid data types raise ValidationError (incorrect data type for operational parameters)"""
+        bad_data = self.generate_engine_data(
+            rated_thrust="high", 
+            bp_ratio="low", 
+            pressure_ratio="nope"
+        )
+        engine = Engine(**bad_data)
+        with self.assertRaises(ValidationError):
+            engine.full_clean()
+
+    def test_duplicate_engine_identification(self):
+        """Test that duplicate engine_identification raises IntegrityError (unique constraint on engine_identification)"""
+        ident = "DUPLICATE_ENGINE_001"
+        Engine.objects.create(**self.generate_engine_data(engine_identification=ident))
+        with self.assertRaises(IntegrityError):
+            Engine.objects.create(**self.generate_engine_data(engine_identification=ident))


### PR DESCRIPTION
## Engine Model Test Cases

### Expected Behavior: Should throw an error

- Missing `user_id`
- `user_id` provided but not found in the database
- Operational parameter has incorrect data type
- Missing required operational parameter (e.g., `engine_type`)

### Expected Behavior: Should insert into the database

- All required fields are present and valid (`user_id`, `engine_type`, `engine_identification`, `rated_thrust`, etc.)

### Additional Tests Added:

- When `engine_identification` is not unique within the same `user_id`
- Validation-only tests for required fields (`user_id`, `engine_type`, `engine_identification`, `rated_thrust`)

### Output when ran: 
```
emission-analyzer-service % docker-compose exec web python manage.py test emission_analyzer_api.tests.engine
 
Found 6 test(s).
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
......
----------------------------------------------------------------------
Ran 6 tests in 0.013s

OK
Destroying test database for alias 'default'...```